### PR TITLE
Fixing JSON format in slaves.json

### DIFF
--- a/auto_create_table/slaves.json
+++ b/auto_create_table/slaves.json
@@ -23,7 +23,7 @@
          "precision":"0"
       },
       {
-         "name":"last_response_time"
+         "name":"last_response_time",
          "type":"Integer",
          "flength":"7",
          "precision":"0"


### PR DESCRIPTION
Just adding a missing comma to one of the json files which prevented the json file from parsing properly :)

Thanks

Steve
